### PR TITLE
add centos and rpm based distribution support

### DIFF
--- a/roles/vector/molecule/default/molecule.yml
+++ b/roles/vector/molecule/default/molecule.yml
@@ -45,6 +45,15 @@ platforms:
       - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: centos8
+    image: jrei/systemd-centos:8
+    privileged: true
+    command: /usr/sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 provisioner:
   name: ansible

--- a/roles/vector/tasks/main.yml
+++ b/roles/vector/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Install Vector
+- name: Install Vector (Debian)
   apt:
     deb: "https://packages.timber.io/vector/{{ version }}/vector-{{ arch }}.deb"
     install_recommends: yes
@@ -7,6 +7,19 @@
   vars:
     version: "{{ vector_nightly | ternary('nightly/latest','latest') }}"
     arch: "{{ vector_debian_arch[ansible_machine] }}"
+  when: ansible_os_family == 'Debian'
+
+- name: Install Vector (RedHat)
+  yum:
+    name: "https://packages.timber.io/vector/{{ version }}/vector-{{ arch }}.rpm"
+    state: present
+    disable_gpg_check: yes # package is not signed
+  notify:
+    - restart vector
+  vars:
+    version: "{{ vector_nightly | ternary('nightly/latest','latest') }}"
+    arch: "{{ vector_redhat_arch[ansible_machine] }}"
+  when: ansible_os_family == 'RedHat'
 
 - name: Copy config
   template:

--- a/roles/vector/vars/main.yml
+++ b/roles/vector/vars/main.yml
@@ -2,3 +2,7 @@ vector_debian_arch:
   armv7l: armhf
   aarch64: arm64
   x86_64: amd64
+vector_redhat_arch:
+  armv7l: armv7hl
+  aarch64: aarch64
+  x86_64: x86_64


### PR DESCRIPTION
I added test for centos 8 only (centos 7 is not supported by vector).