### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/new_version.yml
+++ b/.github/workflows/new_version.yml
@@ -3,9 +3,8 @@
 name: publish
 
 on:
-  create:
-    tags:
-      - v*
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -15,7 +14,7 @@ jobs:
 
       # Sets RELEASE_VERSION to be refs/tags/v<version> -> <version>
       - name: Get the version from the tag
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF#refs/tags/v})
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Upload to ansible-galaxy
         uses: artis3n/ansible_galaxy_collection@v2

--- a/.github/workflows/new_version.yml
+++ b/.github/workflows/new_version.yml
@@ -3,8 +3,9 @@
 name: publish
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - v*
 
 jobs:
   deploy:


### PR DESCRIPTION
The previous on clause was not working properly since the action was launched each time I pushed a branch on my fork.
Using solution from github action documentation should help I hope.
The set-enc command was deprecated so I switched to the environment file as suggested by deprecation notice