### PR TITLE
Allow to choose which version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 This is an ansible role to set up [vector](https://vector.dev).
 It translates the YAML configuration to TOML, so any configuration is possible.
 
-For available variables check out [defaults](defaults/main.yml)
+For available variables check out [defaults](roles/vector/defaults/main.yml)
 
-Currently only amd64 is supported
+Currently only amd64, arch64, arch7 through deb and rpm packages are supported

--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -1,4 +1,5 @@
 vector_nightly: no
+vector_version: "{{ vector_nightly | ternary('nightly','latest') }}"
 add_vector_docker_group: no # Add vector user to "docker" group
 add_vector_journal_group: no # Add vector user to "systemd-journal" group
 

--- a/roles/vector/molecule/default/converge.yml
+++ b/roles/vector/molecule/default/converge.yml
@@ -5,3 +5,5 @@
     - name: "Include vector"
       include_role:
         name: "vector"
+      vars:
+        vector_version: 0.11.1

--- a/roles/vector/tasks/main.yml
+++ b/roles/vector/tasks/main.yml
@@ -1,23 +1,24 @@
 - name: Install Vector (Debian)
   apt:
-    deb: "https://packages.timber.io/vector/{{ version }}/vector-{{ arch }}.deb"
+    deb: "https://packages.timber.io/vector/{{ version }}/vector-{{ version }}-{{ arch }}.deb"
     install_recommends: yes
   notify:
     - restart vector
   vars:
-    version: "{{ vector_nightly | ternary('nightly/latest','latest') }}"
+    version: "{{ (vector_version == 'nightly')| bool | ternary('nightly/latest', vector_version) }}"
     arch: "{{ vector_debian_arch[ansible_machine] }}"
   when: ansible_os_family == 'Debian'
 
 - name: Install Vector (RedHat)
   yum:
-    name: "https://packages.timber.io/vector/{{ version }}/vector-{{ arch }}.rpm"
+    name: "https://packages.timber.io/vector/{{ version }}/vector-{{ package_version }}.{{ arch }}.rpm"
     state: present
     disable_gpg_check: yes # package is not signed
   notify:
     - restart vector
   vars:
-    version: "{{ vector_nightly | ternary('nightly/latest','latest') }}"
+    version: "{{ (vector_version == 'nightly')| bool | ternary('nightly/latest', vector_version) }}"
+    package_version: "{{ vector_version is match('latest') | ternary(vector_version, vector_version ~ '-1') }}"
     arch: "{{ vector_redhat_arch[ansible_machine] }}"
   when: ansible_os_family == 'RedHat'
 


### PR DESCRIPTION
It will help avoiding the latest url being broken (https://github.com/timberio/vector/issues/5486)