### PR TITLE
Sort array to ensure idempotence

### DIFF
--- a/roles/vector/templates/vector.toml.j2
+++ b/roles/vector/templates/vector.toml.j2
@@ -7,11 +7,11 @@ data_dir = "/var/lib/vector"
     "sinks": (sinks | default({}))
 } %}
 
-{% for name, cat in loop_helper.items() %}
-{% for key, value in cat.items() %}
+{% for name, cat in loop_helper.items() | sort(attribute='0') %}
+{% for key, value in cat.items() | sort(attribute='0') %}
 [{{ name }}.{{ key }}]
   {% if value %}
-  {%- for skey, svalue in value.items() %}
+  {%- for skey, svalue in value.items() | sort(attribute='0') %}
   {{ skey }} = {{ svalue | tojson }}
   {% endfor %}
   {%- endif %}


### PR DESCRIPTION
With quite a lot of transforms and sources, the configuration creation becomes non idempotent. Sorting array in the template seems to fix the issue 