### PR TITLE
Fix string escaping

### DIFF
--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -8,6 +8,12 @@ sources:
     type: journald
     current_boot_only: true
 
+transforms:
+  grok:
+    type: grok_parser
+    inputs:
+      - journald
+    pattern: '(?<capture>\\d+)%{GREEDYDATA}'
 sinks:
   vector:
     type: vector

--- a/roles/vector/molecule/default/verify.yml
+++ b/roles/vector/molecule/default/verify.yml
@@ -7,7 +7,14 @@
     command: vector --version
     changed_when: false
     register: vector_version_rc
+  - name: Check grok pattern is not mangled
+    lineinfile:
+      path: /etc/vector/vector.toml
+      line: '    pattern = "(?<capture>\\d+)%{GREEDYDATA}"'
+    diff: true
+    register: grok_pattern_rc
   - name: Assert vector is installed
     assert:
       that:
         - vector_version_rc is success
+        - grok_pattern_rc is not changed

--- a/roles/vector/templates/vector.toml.j2
+++ b/roles/vector/templates/vector.toml.j2
@@ -12,7 +12,11 @@ data_dir = "/var/lib/vector"
 [{{ name }}.{{ key }}]
   {% if value %}
   {%- for skey, svalue in value.items() | sort(attribute='0') %}
+{%- if svalue is string %}
+  {{ skey }} = "{{ svalue }}"
+{% else %}
   {{ skey }} = {{ svalue | tojson }}
+{% endif %}
   {% endfor %}
   {%- endif %}
 


### PR DESCRIPTION
the tojson jinja filter mangles `<` which prevents grok pattern to be defined properly.
I added a test and a fix