### PR TITLE
Fix latest as targeted version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,8 +2,10 @@
 name: Tests
 
 on: 
-  - push
-  - pull_request
+  push:
+  pull_request:
+  schedule:
+    - cron: '20 10 * * tue'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/roles/vector/molecule/default/converge.yml
+++ b/roles/vector/molecule/default/converge.yml
@@ -5,5 +5,3 @@
     - name: "Include vector"
       include_role:
         name: "vector"
-      vars:
-        vector_version: 0.11.1

--- a/roles/vector/tasks/main.yml
+++ b/roles/vector/tasks/main.yml
@@ -1,3 +1,16 @@
+# Workaround for latest version being named against a version number
+- name: Get latest version
+  uri:
+    url: https://s3.amazonaws.com/packages.timber.io/?prefix=vector/latest&max-keys=1
+    return_content: true
+  register: bucket_content
+  when: vector_version == "latest"
+
+- name: Set latest version
+  set_fact:
+    vector_version: "{{ bucket_content.content | regex_replace('.*\\n.*<Key>[^-]+-(?P<version>[\\d\\.]+)-.*','\\g<version>') }}"
+  when: vector_version == "latest"
+
 - name: Install Vector (Debian)
   apt:
     deb: "https://packages.timber.io/vector/{{ version }}/vector-{{ version }}-{{ arch }}.deb"


### PR DESCRIPTION
Since latest version are now stored in the latest folder but with the version number in its name, our download failed. This PR aims at guessing the latest version number.
It's correctness is checked by molecule, and to prevent surprises a check is run every week on master to verify it's still working