### PR TITLE
Fix tests

### DIFF
--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -9,7 +9,6 @@ sources:
   journald:
     type: journald
     current_boot_only: true
-
 transforms:
   grok:
     type: grok_parser
@@ -17,7 +16,8 @@ transforms:
       - journald
     pattern: '(?<capture>\\d+)%{GREEDYDATA}'
 sinks:
-  vector:
-    type: vector
-    inputs: ["journald"]
-    address: "vector.example.com:9000"
+  console:
+    type: console
+    encoding.codec: json
+    inputs:
+      - grok

--- a/roles/vector/molecule/default/molecule.yml
+++ b/roles/vector/molecule/default/molecule.yml
@@ -45,8 +45,8 @@ platforms:
       - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  - name: centos8
-    image: jrei/systemd-centos:8
+  - name: rocky8
+    image: rockylinux:8
     privileged: true
     command: /usr/sbin/init
     tmpfs:


### PR DESCRIPTION
Tests were broken for two reasons:
1. Centos 8 image was no working so I switched with rockylinux
2. In recent version of vector, it fails to start if a sink is not available which was the case in the default configuration. Changed to console output